### PR TITLE
Don't download if file with target name exists

### DIFF
--- a/twspace_dl/twspace_dl.py
+++ b/twspace_dl/twspace_dl.py
@@ -104,6 +104,9 @@ class TwspaceDL:
         if not shutil.which("ffmpeg"):
             raise FileNotFoundError("ffmpeg not installed")
         space = self.space
+        if os.path.exists(self.filename + ".m4a"):
+            logging.info("%s has already been downloaded", self.filename + ".m4a")
+            return
         self.write_playlist(save_dir=self._tempdir.name)
         state = space["state"]
 


### PR DESCRIPTION
Simplest way to fix #63: consider download finished if there is existing file in working directory that has the same name as one that would be created.