### PR TITLE
Fix get user ID from user screen name due to API shutdown

### DIFF
--- a/twspace_dl/twitter.py
+++ b/twspace_dl/twitter.py
@@ -2,18 +2,19 @@ import re
 
 import requests
 
+AUTH_HEADER = {
+    "authorization": (
+        "Bearer "
+        "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs"
+        "=1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
+    )
+}
+
 
 def guest_token() -> str:
     """Generate a guest token to authorize twitter api requests"""
-    headers = {
-        "authorization": (
-            "Bearer "
-            "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs"
-            "=1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
-        )
-    }
     response = requests.post(
-        "https://api.twitter.com/1.1/guest/activate.json", headers=headers, timeout=30
+        "https://api.twitter.com/1.1/guest/activate.json", headers=AUTH_HEADER, timeout=30
     ).json()
     token = response["guest_token"]
     if not token:
@@ -24,12 +25,27 @@ def guest_token() -> str:
 def user_id(user_url: str) -> str:
     """Get the id of a twitter using the url linking to their account"""
     screen_name = re.findall(r"(?<=twitter.com/)\w*", user_url)[0]
-    params = {"screen_names": screen_name}
+    params = {
+        "variables": (
+            "{"
+            f'"screen_name":"{screen_name}",'
+            '"withSafetyModeUserFields":true,'
+            '"withSuperFollowsUserFields":true'
+            "}"
+        ),
+        "features": (
+            "{"
+            '"responsive_web_twitter_blue_verified_badge_is_enabled":true,'
+            '"verified_phone_label_enabled":false,'
+            '"responsive_web_graphql_timeline_navigation_enabled":true'
+            "}"
+        )
+    }
     response = requests.get(
-        "https://cdn.syndication.twimg.com/widgets/followbutton/info.json",
+        "https://api.twitter.com/graphql/hVhfo_TquFTmgL7gYwf91Q/UserByScreenName",
         params=params,
+        headers=AUTH_HEADER | {"x-guest-token": guest_token()},
         timeout=30,
-    )
-    user_data = response.json()
-    usr_id = user_data[0]["id"]
+    ).json()
+    usr_id = response["data"]["user"]["result"]["rest_id"]
     return usr_id


### PR DESCRIPTION
The original API (`https://cdn.syndication.twimg.com/widgets/followbutton/info.json`) was shutdown by Twitter recently, causing the function `user_id()` not being able to retrieve the user ID by the user's screen name, and ultimately making the program to crash.

This PR replaces the old API with a new one to make this program continue to work. It was tested locally and everything seemed working fine.

This should also fix #79.