### PR TITLE
Restore support for Python 3.8

### DIFF
--- a/twspace_dl/twitter.py
+++ b/twspace_dl/twitter.py
@@ -46,7 +46,7 @@ def user_id(user_url: str) -> str:
     response = requests.get(
         "https://api.twitter.com/graphql/hVhfo_TquFTmgL7gYwf91Q/UserByScreenName",
         params=params,
-        headers=AUTH_HEADER | {"x-guest-token": guest_token()},
+        headers={**AUTH_HEADER, **{"x-guest-token": guest_token()}},
         timeout=30,
     ).json()
     usr_id = response["data"]["user"]["result"]["rest_id"]

--- a/twspace_dl/twitter.py
+++ b/twspace_dl/twitter.py
@@ -46,7 +46,7 @@ def user_id(user_url: str) -> str:
     response = requests.get(
         "https://api.twitter.com/graphql/hVhfo_TquFTmgL7gYwf91Q/UserByScreenName",
         params=params,
-        headers={**AUTH_HEADER, **{"x-guest-token": guest_token()}},
+        headers={**AUTH_HEADER, "x-guest-token": guest_token()},
         timeout=30,
     ).json()
     usr_id = response["data"]["user"]["result"]["rest_id"]


### PR DESCRIPTION
The previous update introduced merging two dictionaries together with the | operator, but using the | operator in this way was not supported until 3.9.

This method of merging two dictionaries together retains the simplicity while also being backwards compatible with Python 3.8.