### PR TITLE
Fix new user ID API rate limit and temp directory not being removed issue

### DIFF
--- a/twspace_dl/__main__.py
+++ b/twspace_dl/__main__.py
@@ -3,8 +3,6 @@ import argparse
 import datetime
 import json
 import logging
-import os
-import shutil
 import sys
 from types import TracebackType
 from typing import Iterable, Type
@@ -125,8 +123,8 @@ def space(args: argparse.Namespace) -> int:
         except KeyboardInterrupt:
             logging.info("Download Interrupted by user")
         finally:
-            if not args.keep_files and os.path.exists(twspace_dl.tempdir):
-                shutil.rmtree(twspace_dl.tempdir)
+            if not args.keep_files:
+                twspace_dl.cleanup()
     return EXIT_CODE_SUCCESS
 
 

--- a/twspace_dl/twitter.py
+++ b/twspace_dl/twitter.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import tempfile
 import time
@@ -34,8 +35,11 @@ def guest_token(refresh: bool = False) -> str:
                 timeout=30,
             ).json()
             if GUEST_TOKEN := response["guest_token"]:
-                with open(GUEST_TOKEN_FILE, "w") as f:
-                    f.write(GUEST_TOKEN)
+                try:
+                    with open(GUEST_TOKEN_FILE, "w") as f:
+                        f.write(GUEST_TOKEN)
+                except OSError as e:
+                    logging.error(e)
             else:
                 raise RuntimeError("No guest token found after five retry")
     return GUEST_TOKEN

--- a/twspace_dl/twitter.py
+++ b/twspace_dl/twitter.py
@@ -1,6 +1,10 @@
 import re
+import tempfile
+import time
+from os.path import getmtime, join
 
 import requests
+
 
 AUTH_HEADER = {
     "authorization": (
@@ -9,19 +13,32 @@ AUTH_HEADER = {
         "=1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
     )
 }
+GUEST_TOKEN = None
+GUEST_TOKEN_FILE = join(tempfile.gettempdir(), "twspace_dl-guest_token")
+GUEST_TOKEN_TIMEOUT = 1800
 
 
-def guest_token() -> str:
+def guest_token(refresh: bool = False) -> str:
     """Generate a guest token to authorize twitter api requests"""
-    response = requests.post(
-        "https://api.twitter.com/1.1/guest/activate.json",
-        headers=AUTH_HEADER,
-        timeout=30,
-    ).json()
-    token = response["guest_token"]
-    if not token:
-        raise RuntimeError("No guest token found after five retry")
-    return token
+    global GUEST_TOKEN
+    if not GUEST_TOKEN or refresh:
+        try:
+            if refresh or time.time() - getmtime(GUEST_TOKEN_FILE) > GUEST_TOKEN_TIMEOUT:
+                raise FileNotFoundError
+            with open(GUEST_TOKEN_FILE) as f:
+                GUEST_TOKEN = f.read()
+        except FileNotFoundError:
+            response = requests.post(
+                "https://api.twitter.com/1.1/guest/activate.json",
+                headers=AUTH_HEADER,
+                timeout=30,
+            ).json()
+            if GUEST_TOKEN := response["guest_token"]:
+                with open(GUEST_TOKEN_FILE, "w") as f:
+                    f.write(GUEST_TOKEN)
+            else:
+                raise RuntimeError("No guest token found after five retry")
+    return GUEST_TOKEN
 
 
 def user_id(user_url: str) -> str:
@@ -43,11 +60,16 @@ def user_id(user_url: str) -> str:
             "}"
         ),
     }
-    response = requests.get(
+    session = requests.Session()
+    req = requests.Request(
+        "GET",
         "https://api.twitter.com/graphql/hVhfo_TquFTmgL7gYwf91Q/UserByScreenName",
         params=params,
-        headers={**AUTH_HEADER, "x-guest-token": guest_token()},
-        timeout=30,
-    ).json()
-    usr_id = response["data"]["user"]["result"]["rest_id"]
+        headers={**AUTH_HEADER, "x-guest-token": guest_token()}
+    ).prepare()
+    response = session.send(req, timeout=30)
+    if response.status_code == requests.codes.too_many_requests:
+        req.headers.update({"x-guest-token": guest_token(True)})
+        response = session.send(req)
+    usr_id = response.json()["data"]["user"]["result"]["rest_id"]
     return usr_id

--- a/twspace_dl/twitter.py
+++ b/twspace_dl/twitter.py
@@ -48,22 +48,15 @@ def user_id(user_url: str) -> str:
         "variables": (
             "{"
             f'"screen_name":"{screen_name}",'
-            '"withSafetyModeUserFields":true,'
-            '"withSuperFollowsUserFields":true'
+            '"withSafetyModeUserFields":false,'
+            '"withSuperFollowsUserFields":false'
             "}"
-        ),
-        "features": (
-            "{"
-            '"responsive_web_twitter_blue_verified_badge_is_enabled":true,'
-            '"verified_phone_label_enabled":false,'
-            '"responsive_web_graphql_timeline_navigation_enabled":true'
-            "}"
-        ),
+        )
     }
     session = requests.Session()
     req = requests.Request(
         "GET",
-        "https://api.twitter.com/graphql/hVhfo_TquFTmgL7gYwf91Q/UserByScreenName",
+        "https://twitter.com/i/api/graphql/7mjxD3-C6BxitPMVQ6w0-Q/UserByScreenName",
         params=params,
         headers={**AUTH_HEADER, "x-guest-token": guest_token()}
     ).prepare()

--- a/twspace_dl/twspace_dl.py
+++ b/twspace_dl/twspace_dl.py
@@ -25,7 +25,7 @@ class TwspaceDL:
         self.session.mount(
             "https://", HTTPAdapter(max_retries=(Retry(total=5, backoff_factor=0.1)))
         )
-        self._tempdir = tempfile.mkdtemp(dir=".")
+        self._tempdir = ""
 
     @cached_property
     def filename(self) -> str:
@@ -99,16 +99,12 @@ class TwspaceDL:
             stream_io.write(self.playlist_text)
         logging.debug("%(path)s written to disk", dict(path=path))
 
-    @property
-    def tempdir(self):
-        """Return tempdir"""
-        return self._tempdir
-
     def download(self) -> None:
         """Download a twitter space"""
         if not shutil.which("ffmpeg"):
             raise FileNotFoundError("ffmpeg not installed")
         space = self.space
+        self._tempdir = tempfile.mkdtemp(dir=".")
         self.write_playlist(save_dir=self._tempdir)
         state = space["state"]
 
@@ -184,3 +180,7 @@ class TwspaceDL:
             shutil.move(filename_old, self.filename + ".m4a")
 
         logging.info("Finished downloading")
+
+    def cleanup(self):
+        if os.path.exists(self._tempdir):
+            shutil.rmtree(self._tempdir)


### PR DESCRIPTION
Fixes #82.
Fixes #73.

The file location of the proposed on-disk `guest_token` cache was set to a file in the temp directory on the system as it was rotated fairly often.